### PR TITLE
Fix time zone issue

### DIFF
--- a/PowerwallCompanion/DateUtils.cs
+++ b/PowerwallCompanion/DateUtils.cs
@@ -18,7 +18,7 @@ namespace PowerwallCompanion
             try
             {
                 var siteInfoJson = await ApiHelper.CallGetApiWithTokenRefresh($"/api/1/energy_sites/{Settings.SiteId}/site_info", "SiteInfo");
-                Settings.InstallationTimeZone = siteInfoJson["respose"]["installation_time_zone"].Value<string>();
+                Settings.InstallationTimeZone = siteInfoJson["response"]["installation_time_zone"].Value<string>();
             }
             catch
             {

--- a/PowerwallCompanion/ViewModels/BatteryInfoViewModel.cs
+++ b/PowerwallCompanion/ViewModels/BatteryInfoViewModel.cs
@@ -30,7 +30,7 @@ namespace PowerwallCompanion.ViewModels
         public double TotalPackEnergy { get; set; }
 
         public double CurrentCapacityPercent { get { return TotalPackEnergy / WarrantedCapacity * 100; } }
-        public double Degradation { get { return CurrentCapacityPercent > 100 ? 0 : 100 - CurrentCapacityPercent; } }
+        public double Degradation { get { return CurrentCapacityPercent > 100 ? 0 : 100.0 - CurrentCapacityPercent; } }
         public string GatewayId { get; set; }
 
         public List<ChartDataPoint> BatteryHistoryChartData


### PR DESCRIPTION
Fix a typo that prevented retrieving the installation time zone.
Make sure a double calculation is done using doubles.